### PR TITLE
Added filter `outfilter'.

### DIFF
--- a/filters/outfilter
+++ b/filters/outfilter
@@ -1,0 +1,30 @@
+#! /usr/bin/perl
+use lib ($ENV{RLWRAP_FILTERDIR} or ".");
+use RlwrapFilter;
+use strict;
+
+my $filter = new RlwrapFilter;
+my $name = $filter->name;
+
+my $filter_command = join ' ', @ARGV;
+
+$filter->help_text("Usage: rlwrap -z '$name <filter-command>' <command>\n"
+                   . "Filter <command> output through <filter-command>");
+
+$filter->output_handler(sub {""});
+$filter->prompt_handler(\&prompt);
+$filter->run;
+
+sub prompt {
+    my $prompt = shift;
+
+    my $output = $filter->cumulative_output;
+    $output =~ s/\r//g;
+
+    open (PIPE, "| $filter_command")
+        or die "Failed to create pipe: $!";
+    print PIPE $output;
+    close PIPE;
+
+    return $prompt;
+}


### PR DESCRIPTION
This adds a new filter, `outfilter`, that allows one to choose a shell command that each block of output will be filtered through. The code is barely documented, inefficient and probably fragile, and is only meant as a starting point.