### PR TITLE
Extend rlwrap to track slave's cwd on Darwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,10 +105,10 @@ AC_CHECK_HEADERS([ term.h  ncurses/term.h], , ,
 
 # Check for libproc header needed for MacOS to follow slave's current
 # working directory.
-AC_CHECK_HEADER([stdio.h],
+AC_CHECK_HEADER([libproc.h],
                  [AC_DEFINE([HAVE_LIBPROC_H], [1],
                      [Define to 1 if you have <libproc.h>.])],
-                 [AC_MSG_ERROR([no tracking of slave paths on Darwin])])
+                 [AC_MSG_WARN([no tracking of slave paths on Darwin])])
 
 
 # Found this in configure.ac for 'top':

--- a/configure.ac
+++ b/configure.ac
@@ -103,6 +103,12 @@ AC_CHECK_HEADERS([ term.h  ncurses/term.h], , ,
      #include <curses.h>
      #endif])
 
+# Check for libproc header needed for MacOS to follow slave's current
+# working directory.
+AC_CHECK_HEADER([stdio.h],
+                 [AC_DEFINE([HAVE_LIBPROC_H], [1],
+                     [Define to 1 if you have <libproc.h>.])],
+                 [AC_MSG_ERROR([no tracking of slave paths on Darwin])])
 
 
 # Found this in configure.ac for 'top':

--- a/src/rlwrap.h
+++ b/src/rlwrap.h
@@ -181,9 +181,9 @@ extern int _rl_horizontal_scroll_mode;
 #  define redisplay_multiple_lines (strncmp(rl_variable_value("horizontal-scroll-mode"),"off",3) == 0)
 #endif
 
-
-
-
+#if defined(HAVE_LIBPROC_H)
+#  include <libproc.h>
+#endif
 
 
 /* in main.c: */
@@ -330,6 +330,7 @@ void  write_logfile(const char *str);
 void  close_logfile(void);
 void  timestamp(char *buf, int size);
 int   killed_by(int status);
+void  update_cwd_for_slave_using_libproc(int pid);
 void  change_working_directory(void);
 void  log_terminal_settings(struct termios *terminal_settings);
 void  log_fd_info(int fd);
@@ -491,7 +492,6 @@ void filter_test(void);
 /* DPRINTF0 and its ilk  doesn't produce any output except when DEBUG is #defined (via --enable-debug configure option) */
 
 #ifdef  DEBUG
-
 
 #  define DEBUG_TERMIO                           1
 #  define DEBUG_SIGNALS                          2


### PR DESCRIPTION
Darwin offers the libproc facility to determine the current working
directory of a slave process. Extend rlwrap to use this facility where
available.
