### PR TITLE
base64-encode elements of filter_food

### DIFF
--- a/filters/RlwrapFilter.pm
+++ b/filters/RlwrapFilter.pm
@@ -4,6 +4,7 @@ require 5.006;
 
 use strict;
 use vars qw($VERSION @ISA @EXPORT @EXPORT_OK $AUTOLOAD);
+use MIME::Base64;
 
 sub when_defined($@);
 my $previous_tag = -1;
@@ -129,7 +130,15 @@ sub run {
         } elsif ($tag == TAG_HOTKEY) {
           if ($self -> hotkey_handler) {
             my @params = split /\t/, $message;
+            @params[0] = decode_base64(@params[0]); # hotkey
+            @params[1] = decode_base64(@params[1]); # prefix
+            @params[2] = decode_base64(@params[2]); # postfix
+            @params[3] = decode_base64(@params[3]); # history
             my @result = &{$self -> hotkey_handler}(@params);
+            @result[0] = encode_base64(@result[0]); # message
+            @result[1] = encode_base64(@result[1]); # new prefix
+            @result[2] = encode_base64(@result[2]); # new postfix
+            @result[3] = encode_base64(@result[3]); # new history
             $response = join("\t", @result);
           } else {
             $response = $message;

--- a/filters/handle_hotkeys
+++ b/filters/handle_hotkeys
@@ -15,6 +15,7 @@ my $keymap =
   "n" => \&edit_history, 
   "r" => \&peco_history, 
   "t" => \&date_in_echo_area,
+  "i" => \&peco_history
 };  
 
 my @tempfiles; # list of files to be cleaned on exit;

--- a/filters/handle_hotkeys.py
+++ b/filters/handle_hotkeys.py
@@ -134,6 +134,7 @@ keymap = {
     "y" : yank_clipboard,
     "n" : edit_history,
     "r" : peco_history,
+    "i" : peco_history, # tab
     "t" : date_in_echo_area
 }
 
@@ -163,9 +164,8 @@ def document_all_hotkeys():
 
 def safe_backtick(command_args):
     with subprocess.Popen(command_args, stdout=subprocess.PIPE, universal_newlines=True) as p:
-        #result = map(lambda b: b.decode("utf-8"), p.stdout.readlines())
         (result, error) = p.communicate()
-    return ''.join(result).rstrip()
+    return result.rstrip()
 
 
 # give back corresponding CTRL-key. E.g: control("m") = "\0x13"

--- a/filters/rlwrapfilter.py
+++ b/filters/rlwrapfilter.py
@@ -47,6 +47,7 @@ import traceback
 import binascii
 import collections
 import numbers
+import base64
 
 TAG_INPUT                       = 0
 TAG_OUTPUT                      = 1
@@ -315,6 +316,14 @@ def test_intercept():
     raise Exception('test exception = = = = = .........')
 
 
+def base64_decode(string):
+    return str(base64.b64decode(bytes(string, sys.stdin.encoding)), sys.stdin.encoding)
+
+
+def base64_encode(string):
+    return str(base64.b64encode(bytes(string, sys.stdin.encoding)), sys.stdin.encoding)
+
+
 class RlwrapFilterError(Exception):
     """
     A custom exception for rlwrap
@@ -550,7 +559,15 @@ class RlwrapFilter:
             elif (tag == TAG_HOTKEY):
                 if (self.hotkey_handler is not None):
                     params = message.split("\t")
-                    result = self.hotkey_handler(*params)
+                    params[0] = base64_decode(params[0]) # hotkey
+                    params[1] = base64_decode(params[1]) # prefix
+                    params[2] = base64_decode(params[2]) # postfix
+                    params[3] = base64_decode(params[3]) # history
+                    result = list(self.hotkey_handler(*params))
+                    result[0] = base64_encode(result[0]) # message
+                    result[1] = base64_encode(result[1]) # new prefix
+                    result[2] = base64_encode(result[2]) # new postfix
+                    result[3] = base64_encode(result[3]) # new history
                     response = "\t".join(result)
                 else:
                     response = message

--- a/src/rlwrap.h
+++ b/src/rlwrap.h
@@ -385,6 +385,9 @@ char *get_last_screenline(char *long_line, int termwidth);
 char *lowercase(const char *str);
 char *colour_name_to_ansi_code(const char *colour_name);
 int match_regexp(const char *string, const char *regexp, int case_insensitive);
+#define NOT_A_BASE64_CHAR 0x100
+char * base64_encode(char *str);
+char * base64_decode(char *str);
 
 
 /* in pty.c: */

--- a/src/string_utils.c
+++ b/src/string_utils.c
@@ -896,3 +896,112 @@ int match_regexp (const char *string, const char *regexp, int case_insensitive) 
   
   return result;        
 }
+
+
+/*
+  returns base64-encoded string which may be compliant with 
+  https://en.wikipedia.org/wiki/Base64#RFC_4648 as possible, e.g., char for
+  index 62 is '+', char for index 63 = '/', pad char is '=', and it has no
+  CR/LF. Memory of the value is obtained with malloc() and have to be freed
+  with free().
+*/
+char *
+base64_encode(char *str)
+{
+  char *base64_enc_map = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+  char *pstr = str;
+  char *enc = malloc(((strlen(str)*4/3 + 3) & ~0x03) + 1);
+  char *penc = enc;
+  
+  int bits = 0;
+  
+  
+  for (; *pstr; pstr++) {
+    bits = bits << 8 | *pstr;
+    if ((uintptr_t)(pstr - str) % 3 == 0) {
+      *penc++ = base64_enc_map[(bits >> 2) & 0x3f];
+    }
+    else if ((uintptr_t)(pstr - str) % 3 == 1) {
+      *penc++ = base64_enc_map[(bits >> 4) & 0x3f];
+    }
+    else if ((uintptr_t)(pstr - str) % 3 == 2) {
+      *penc++ = base64_enc_map[(bits >> 6) & 0x3f];
+      *penc++ = base64_enc_map[bits & 0x3f];
+    }
+  }
+
+  // edge process
+  if ((uintptr_t)(pstr - str) % 3 == 1) {
+    *penc++ = base64_enc_map[(bits << 4) & 0x3f];
+    *penc++ = '=';
+    *penc++ = '=';
+  }
+  else if ((uintptr_t)(pstr -str) % 3 == 2) {
+    *penc++ = base64_enc_map[(bits << 2) & 0x3f];
+    *penc++ = '=';
+  }
+
+  *penc = '\0';
+
+  assert((uintptr_t)(penc - enc) % 4 == 0);
+  
+  return enc;
+}
+
+
+/* maps base64-char to bits */
+int base64_dec_map(char c) {
+  if (isupper(c)) return c - 'A';
+  if (islower(c)) return c - 'a' + 26;
+  if (isdigit(c)) return c - '0' + 26 + 26;
+  if (c == '+') return 62;
+  if (c == '/') return 63;
+  if (c == '=') return 0;
+  return NOT_A_BASE64_CHAR;
+}
+
+
+/*
+  returns base64-decoded string ignoring non-base64-chars. An effective
+  length of str must be multiple of 4, otherwise, it will die. Memory of
+  the value is obtained with malloc() and have to be freed with free().
+*/
+char *
+base64_decode(char *str)
+{
+  char *pstr = str;
+  char *dec = malloc(strlen(str)*3/4 + 1);
+  char *pdec = dec;
+  int skip_count = 0;
+  
+  int bits;
+  
+  while(1) {
+    // fetch 4 bytes of base64-char
+    int i=0;
+    while(i<4) {
+      if (*pstr == '\0') goto OUT;
+      // transform base64-char into 6-bit integer
+      int c = base64_dec_map(*pstr++);
+      if (c == NOT_A_BASE64_CHAR) {
+        skip_count++;
+        continue;
+      }
+      // concatinate
+      bits = (bits << 6) | c;
+      i++;
+    }
+    // split it into 3 bytes
+    *pdec++ = (bits & 0xff0000) >> 16;
+    *pdec++ = (bits & 0x00ff00) >> 8;
+    *pdec++ = (bits & 0x0000ff);
+  }
+ OUT:
+  *pdec = '\0';
+
+  assert(((uintptr_t)(pstr - str) - skip_count) % 4 == 0);
+
+  return dec;
+}
+


### PR DESCRIPTION
Since filter_food in handle_hotkey2 is a string which consists of raw chars concatenated by '\t'(tab), it causes limitations like:
* Tab key can not be used as a hotkey.
* The hotkey feature does not work with multibyte chars like Japanese.

The idea is base64-encoding each element in filter_food.