### PR TITLE
-C option accepts a non-numeric argument

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -867,7 +867,8 @@ read_options_and_command_name(int argc, char **argv)
     }
   }
   if (opt_C) {
-    int countback = my_atoi(opt_C);	/* investigate whether -C option argument is numeric */
+    int countback = 0;
+    if (isnumeric(opt_C)) countback = my_atoi(opt_C);	/* investigate whether -C option argument is numeric */
 
     if (countback > 0) {	/* e.g -C 1 or -C 12 */
       if (argc - countback < optind)	/* -C 666 */

--- a/src/rlwrap.h
+++ b/src/rlwrap.h
@@ -385,7 +385,7 @@ char *get_last_screenline(char *long_line, int termwidth);
 char *lowercase(const char *str);
 char *colour_name_to_ansi_code(const char *colour_name);
 int match_regexp(const char *string, const char *regexp, int case_insensitive);
-
+int isnumeric(char *string);
 
 /* in pty.c: */
 pid_t my_pty_fork(int *, const struct termios *, const struct winsize *);

--- a/src/string_utils.c
+++ b/src/string_utils.c
@@ -896,3 +896,14 @@ int match_regexp (const char *string, const char *regexp, int case_insensitive) 
   
   return result;        
 }
+
+
+/* returns TRUE if string is numeric, otherwise FALSE */
+int isnumeric(char *string){
+  char *pstr = string;
+
+  while (*pstr != '\0')
+    if (!isdigit(*pstr++)) return FALSE;
+
+  return TRUE;
+}


### PR DESCRIPTION
rlwrap exits when -C has a non-numeric argument.

how to reproduce:
~~~
$ rlwrap -C dog cat
rlwrap: error: Could not make sense of <dog> as an integer
~~~