### PR TITLE
tag2name() returns None when tab=TAG_WHAT_ARE_YOUR_INTERESTS in pytho…

### DIFF
--- a/filters/rlwrapfilter.py
+++ b/filters/rlwrapfilter.py
@@ -224,6 +224,7 @@ def tag2name(tag):
     """
     for name in ['TAG_REMOVE_FROM_COMPLETION_LIST',
                  'TAG_ADD_TO_COMPLETION_LIST',
+                 'TAG_WHAT_ARE_YOUR_INTERESTS',
                  'TAG_INPUT',
                  'TAG_PROMPT',
                  'TAG_COMPLETION',


### PR DESCRIPTION
In python filter, tag2name() returns None when tab=TAG_WHAT_ARE_YOUR_INTERESTS. You can observe it using the sample filter `logger.py`.
how to reproduce:
~~~
$ rlwrap -z 'logger.py -l /tmp/logger.py.log' cat
rlwrapfilter: improper handler <<function logit at 0x7ff4ea003e18>> of type <class 'function'> (expected a ref to a sub)
Traceback (most recent call last):
  File "/usr/local/share/rlwrap/filters/rlwrapfilter.py", line 96, in when_defined
    return maybe_ref_to_sub(*args)
  File "/usr/local/share/rlwrap/filters/logger.py", line 36, in logit
    tagname = re.sub(r'^TAG_', '', tagname)
  File "/usr/lib64/python3.5/re.py", line 182, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object
Traceback (most recent call last):
  File "/usr/local/share/rlwrap/filters/logger.py", line 62, in <module>
    filter.run()
  File "/usr/local/share/rlwrap/filters/rlwrapfilter.py", line 533, in run
    message = when_defined(self.message_handler, message, tag) # ignore return value
  File "/usr/local/share/rlwrap/filters/rlwrapfilter.py", line 100, in when_defined
    .format(maybe_ref_to_sub, type(maybe_ref_to_sub), traceback.format_exc()),e)
  File "/usr/local/share/rlwrap/filters/rlwrapfilter.py", line 258, in send_error
    raise e
  File "/usr/local/share/rlwrap/filters/rlwrapfilter.py", line 96, in when_defined
    return maybe_ref_to_sub(*args)
  File "/usr/local/share/rlwrap/filters/logger.py", line 36, in logit
    tagname = re.sub(r'^TAG_', '', tagname)
  File "/usr/lib64/python3.5/re.py", line 182, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object
rlwrap: error: EOF reading from filter
rlwrap: warning: filter died

warnings can be silenced by the --no-warnings (-n) option
~~~