### PR TITLE
Added -Q option to inject resizing command when SIGWINCH received

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -75,7 +75,6 @@ int we_just_got_a_signal_or_EOF = FALSE;  /* When we got a signal or EOF, and th
 					     as a response to user input - i.e. preserve a cooked prompt and just print the new output after it */
 int rlwrap_already_prompted = FALSE;
 int accepted_lines =  0; /* number of lines accepted (used for one-shot rlwrap) */
-char* q_resize_cmd="system \"c \", first system[\"stty size\"]\n";
 
 /* private variables */
 static char *history_filename = NULL;
@@ -95,7 +94,6 @@ static void fork_child(char *command_name, char **argv);
 static char *read_options_and_command_name(int argc, char **argv);
 static void main_loop(void);
 static void test_main(void);
-
 
 
 /* options */

--- a/src/rlwrap.h
+++ b/src/rlwrap.h
@@ -233,7 +233,6 @@ extern int accepted_lines;
 extern char *filter_command;
 extern int polling;
 extern int Q_mode;
-extern char* q_resize_cmd;
 
 void cleanup_rlwrap_and_exit(int status);
 void put_in_output_queue(char *stuff);

--- a/src/rlwrap.h
+++ b/src/rlwrap.h
@@ -232,6 +232,8 @@ extern int commands_children_not_wrapped;
 extern int accepted_lines;
 extern char *filter_command;
 extern int polling;
+extern int Q_mode;
+extern char* q_resize_cmd;
 
 void cleanup_rlwrap_and_exit(int status);
 void put_in_output_queue(char *stuff);

--- a/src/signals.c
+++ b/src/signals.c
@@ -314,7 +314,7 @@ adapt_tty_winsize(int from_fd, int to_fd)
     }
 
     if (Q_mode) {
-      fprintf(fdopen(to_fd, "w"), q_resize_cmd);
+      fprintf(fdopen(to_fd, "w"), "\\c %d %d\n", winsize.ws_col, winsize.ws_row);
     }
     
     return (!always_readline || dont_wrap_command_waits()); /* pass the signal on (except when always_readline is set and command is not waiting) */

--- a/src/signals.c
+++ b/src/signals.c
@@ -312,6 +312,10 @@ adapt_tty_winsize(int from_fd, int to_fd)
       rl_redisplay();
       
     }
+
+    if (Q_mode) {
+      fprintf(fdopen(to_fd, "w"), q_resize_cmd);
+    }
     
     return (!always_readline || dont_wrap_command_waits()); /* pass the signal on (except when always_readline is set and command is not waiting) */
   } else {                      /* window size has not changed */

--- a/src/utils.c
+++ b/src/utils.c
@@ -651,6 +651,7 @@ usage(int status)
   print_option('p', "prompt-colour", "colour", TRUE, NULL);
   print_option('P', "pre-given","input", FALSE, NULL);
   print_option('q', "quote-characters", "chars", FALSE, NULL);
+  print_option('Q', "q-mode", NULL, FALSE, NULL);
   print_option('r', "remember", NULL, FALSE, NULL);
   print_option('R', "renice", NULL, FALSE, NULL);
   print_option('s', "histsize", "N", FALSE,"(negative: readonly)");


### PR DESCRIPTION
This change adds an option to inject a command to resize the terminal into Q (kx.com) which is unable to process SIGWINCH itself.
