### PR TITLE
faster cloak_and_dagger in python filter

### DIFF
--- a/filters/rlwrapfilter.py
+++ b/filters/rlwrapfilter.py
@@ -106,7 +106,8 @@ def out_of_band(tag):
     return tag > 128
 
 
-def read_until(fh, stoptext, timeout):
+def read_until(fh, stoptext, timeout,
+               prompt_search_from=0, prompt_search_to=None):
     """
     read chunks from pty pointed to by fh until either inactive for timeout or stoptext is seen at end-of-chunk
     """
@@ -119,7 +120,8 @@ def read_until(fh, stoptext, timeout):
             return res
         res = res + chunk
         # multi-line mode so that "^" matches a head of each line
-        if re.search(stoptext, res, re.MULTILINE):
+        slice = res[prompt_search_from:prompt_search_to]
+        if re.search(stoptext, slice, re.MULTILINE):
             return res
 
 
@@ -432,7 +434,8 @@ class RlwrapFilter:
         write_message(TAG_REMOVE_FROM_COMPLETION_LIST, ' '.join(args))
 
 
-    def cloak_and_dagger(self, question, prompt, timeout):
+    def cloak_and_dagger(self, question, prompt, timeout,
+                         prompt_search_from=0, prompt_search_to=None):
         """
         have a private chat with the rlwrapped command. This relies very much om the assumption that command stops. 
         talking, and only listens, when it has displayed the prompt
@@ -440,7 +443,9 @@ class RlwrapFilter:
         write_patiently(CMD_IN, bytearray(question + "\n", sys.stdin.encoding))
         if (self.cloak_and_dagger_verbose):
             self.send_output_oob("cloak_and_dagger question: {0}\n".format(question))
-        response = read_until(CMD_OUT, prompt, timeout)
+        response = read_until(CMD_OUT, prompt, timeout,
+                              prompt_search_from=prompt_search_from,
+                              prompt_search_to=prompt_search_to)
         response = re.sub('^.*?\n', '', response) # chop off echoed question;
         response = re.sub('{0}$'.format(prompt), '', response) # chop off prompt;
         if (self.cloak_and_dagger_verbose):


### PR DESCRIPTION
`cloak_and_dagger()` takes many seconds to respond when it receives rlwrapped _command_'s output of huge size(>>100kbytes), because it searches the output for `prompt` to confirm that it reads everything that comes back from _command_ until `prompt` is seen at the end of the read chunk. If you can ensure that `prompt` always matches a reasonably short string, narrowing search area improves response time of `cloak_and_dagger()` without any defects.

I added 2 optional arguments to `cloak_and_dagger()`, `prompt_search_from` and `prompt_search_to`, so that a slice of the output from `prompt_search_from` to `prompt_search_to` is made to be searched for `prompt`. The default values are _0_ and _None_ respectively for backward compatibility that means the total extent of _command_'s output is searched. If either is negative, the index is relative to the end.

## example

* search an entire output of rlwrapped command (same as before)

        rlwrap_filter.cloak_and_dagger(command, prompt, timeout)

* search a substring of the last 256 characters in the output

        rlwrap_filter.cloak_and_dagger(command, prompt, timeout, prompt_search_from=-256)