### PR TITLE
filter quits when rlwrap is killed

### DIFF
--- a/filters/rlwrapfilter.py
+++ b/filters/rlwrapfilter.py
@@ -162,8 +162,8 @@ def write_patiently(fh, buffer):
             if (nwritten <= 0):
                 send_error("error writing: {0}".format(str(buffer)))
             already_written = already_written + nwritten
-        except BrokenPipeError: # ignore harmless error when rlwrap dies
-            pass
+        except BrokenPipeError: # quit when rlwrap dies
+            sys.exit(1)
 
 def read_message():
     """


### PR DESCRIPTION
When rlwrap is killed by SIGKILL, a filter retries write(), and CPU usage spikes.