### PR TITLE
Don't crash if no $HOME.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -579,9 +579,13 @@ init_rlwrap(char *command_line)
   
   /* Determine rlwrap home dir and prefix for default history and completion filenames */
   homedir = (getenv("RLWRAP_HOME") ? getenv("RLWRAP_HOME") : getenv("HOME"));
+  if (!homedir) {
+    homedir = ".";
+    myerror(WARNING | NOERRNO, "No HOME, using '%s'", homedir);
+  }
   homedir_prefix = (getenv("RLWRAP_HOME") ?                    /* is RLWRAP_HOME set?                */
 		    add2strings(getenv("RLWRAP_HOME"), "/") :  /* use $RLWRAP_HOME/<command>_history */
-		    add2strings(getenv("HOME"), "/."));	       /* if not, use ~/.<command>_history   */
+		    add2strings(homedir, "/."));	       /* if not, use ~/.<command>_history   */
 
   /* Determine history file name and check its existence and permissions */
 


### PR DESCRIPTION
rlwrap would crash if HOME was not set.
```
rlwrap: string_utils.c:103: add3strings: Assertion `str1!= ((void *)0)' failed.
Aborted (core dumped)
```

With this change, you instead see:
```
rlwrap: warning: No HOME, using '.'

warnings can be silenced by the --no-warnings (-n) option
```