### PR TITLE
Add missing check for util.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -103,7 +103,7 @@ AC_CHECK_PROG(STRIP,strip,strip,true)
 AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS([errno.h fcntl.h libgen.h libutil.h stdlib.h string.h sched.h sys/ioctl.h sys/wait.h sys/resource.h stddef.h ])
-AC_CHECK_HEADERS([termios.h unistd.h stdint.h time.h getopt.h regex.h curses.h termcap.h ])
+AC_CHECK_HEADERS([termios.h unistd.h stdint.h time.h getopt.h regex.h curses.h termcap.h util.h])
 
 AC_CHECK_HEADERS([ term.h  ncurses/term.h], , ,
     [#ifdef HAVE_CURSES_H


### PR DESCRIPTION
Building rlwrap-0.43 on OS X 10.13, I get:
```
gcc -DHAVE_CONFIG_H -I. -I..   -I/sw/include -DDATADIR=\"/sw/share\"  -g -O2 -M\
T ptytty.o -MD -MP -MF .deps/ptytty.Tpo -c -o ptytty.o ptytty.c
ptytty.c:72:7: warning: implicit declaration of function 'openpty' is invalid i\
n C99 [-Wimplicit-function-declaration]
  if (openpty(&pfd, fd_tty, tty_name, NULL, NULL) != -1) {
      ^
1 warning generated.
```
That function is prototyped via util.h on my platform. I see an #include of it in rlwrap.h (which ptytty.c includes):
```
#ifdef HAVE_PTY_H /* glibc (even if BSD) */
#  include <pty.h>
#elif HAVE_LIBUTIL_H /* BSD, non-glibc */
#  include <libutil.h>
#elif HAVE_UTIL_H /* BSD, other varriants */
#  include <util.h>
#endif
```
and neither HAVE_PTY_H nor HAVE_LIBUTIL_H are defined by my ./configure run (failing to detect the headers). However, ./configure never checks for util.h at all (though it does a successful "checking for openpty in -lutil"), so HAVE_UTIL_H will never be defined.

Attached trivial patch clears the warning for me.