### PR TITLE
Fix list of default break chars in man page

### DIFF
--- a/doc/rlwrap.man.in
+++ b/doc/rlwrap.man.in
@@ -66,7 +66,7 @@ Consider the specified characters word\-breaking (whitespace is
 always word\-breaking). This determines what is considered a "word",
 both when completing and when building a completion word list from
 files specified by \fB\-f\fP options following (not preceding!) it.
-Default list (){}[],'+\-=&^%$#@"";|\\ Unless \-c is specified, \" twice " to keep emacs happy :\-(
+Default list (){}[],'+\-=&^%$#@";|\\ Unless \-c is specified, \" "quote to keep emacs happy
 / and \. (period) are included in the default list.
 .TP
 .OL \-c \-\-complete\-filenames


### PR DESCRIPTION
There are two double quotes in the list of default break chars to keep
Emacs’s syntax coloring happy, but they both appear in the man page too,
which is confusing. Keep Emacs fairly happy with an extra quote in a comment
at the end of the line, but avoid the bogus output.