### PR TITLE
Fix detection of ENABLE_MIRROR_ARGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -453,6 +453,7 @@ else
   $CC -o conftest conftest.c  
   ./conftest $random_nonsense1 >/dev/null 2>&1 &
   CONFTEST_PID=$!
+  sleep 1
   if grep $random_nonsense2 $opt_proc_mountpoint/$CONFTEST_PID/cmdline >/dev/null 2>&1; then
       AC_DEFINE(ENABLE_MIRROR_ARGS, 1, [Define if overwriting argv changes args visible in ps (1)])
       result="yes"

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl  configuration script for rlwrap
 dnl  Process this file with autoconf to produce configure.
 dnl
-dnl  Copyright (C) 2000-20017 Hans Lub hanslub42@gmail.com
+dnl  Copyright (C) 2000-2017 Hans Lub hanslub42@gmail.com
 dnl
 dnl  This file is part of rlwrap
 dnl


### PR DESCRIPTION
While working on reproducible builds for openSUSE, I found that without
this patch, this produced different results on VMs with 1 and 4 cores

also Fix copyright year