### PR TITLE
Fix out of bounds read in configure generated code caught by gcc-11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -452,7 +452,7 @@ else
         [AC_LANG_SOURCE([[#include <unistd.h>
                           #include <string.h>
                           int main(int argc, char **argv) {
-                                       memcpy(*argv, "a\0" RANDOM_NONSENSE2, strlen(RANDOM_NONSENSE2) + 3);
+                                       memcpy(*argv, "a\0" RANDOM_NONSENSE2, strlen(RANDOM_NONSENSE2) + 2);
                                        return(sleep(10));
                                    }
                          ]])])


### PR DESCRIPTION
see https://src.fedoraproject.org/rpms/rlwrap/c/c17bb6a6cadfc69320562b3ae4bd83028535cc15?branch=master

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hanslub42/rlwrap/114)
<!-- Reviewable:end -->
