### PR TITLE
Fix args to setitimer call to prevent EINVAL error on return

### DIFF
--- a/src/rlwrap.h
+++ b/src/rlwrap.h
@@ -40,6 +40,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <math.h>
 #include <inttypes.h>  /* stdint.h is not on AIX, inttypes.h is in ISO C 1999 */
 
 #include <errno.h>

--- a/src/signals.c
+++ b/src/signals.c
@@ -456,7 +456,8 @@ static int myalarm_was_set = FALSE;
 void myalarm(int msecs) {
 #ifdef HAVE_SETITIMER
   struct itimerval awhile = {{0,0},{0,0}};
-  awhile.it_value.tv_usec = msecs * 1000;
+  awhile.it_value.tv_sec = floor(msecs/1000);
+  awhile.it_value.tv_usec = (msecs - awhile.it_value.tv_sec * 1000) * 1000;
   received_sigALRM = FALSE;
   setitimer(ITIMER_REAL, &awhile, NULL);
 #else


### PR DESCRIPTION
If the microseconds value, tv_used is larger than 1000000 an EINVAL
error is returned, so I've changed it to also set the tv_sec value.