### PR TITLE
Time-of-check vs time-of-use "bug" in src/string_utils.c

### DIFF
--- a/src/string_utils.c
+++ b/src/string_utils.c
@@ -338,6 +338,8 @@ char *
 search_and_replace(char *patt, const char *repl, const char *string, int cursorpos,
                    int *line, int *col)
 {
+  assert(patt && repl && string);
+   
   int i, j, k;
   int pattlen = strlen(patt);
   int replen = strlen(repl);
@@ -348,7 +350,6 @@ search_and_replace(char *patt, const char *repl, const char *string, int cursorp
   size_t scratchsize;
   char *scratchpad, *result;
 
-  assert(patt && repl && string);
   DPRINTF2(DEBUG_READLINE, "string=%s, cursorpos=%d",
            M(string), cursorpos);
   scratchsize = max(stringlen, (stringlen * replen) / pattlen) + 1;     /* worst case : repleng > pattlen and string consists of only <patt> */


### PR DESCRIPTION
This PR fixes a small issue where pointers are checked against NULL but the check happens after the pointer was already dereferenced.

Specifically in [src/string_utils.c line 351](https://github.com/hanslub42/rlwrap/blob/master/src/string_utils.c#L351):

`strlen(ptr)` dereferences 'ptr' so if 'patt', 'repl' or 'string' was ever NULL, the program would crash before reaching the `assert`-statement.

See below lines 342, 343, 344 + 351 for comments explaining the issue.

```C
337   char *
338   search_and_replace(char *patt, const char *repl, const char *string, int cursorpos,
339                      int *line, int *col)
340   {
341     int i, j, k;
342     int pattlen = strlen(patt);
                      ^^^^^^^^^^^^ pointer 'patt' gets dereferenced here
343     int replen = strlen(repl);
                     ^^^^^^^^^^^^ pointer 'repl' gets dereferenced here
344     int stringlen = strlen(string);
                     ^^^^^^^^^^^^ pointer 'string' gets dereferenced here
345     int cursor_found = FALSE;
346     int current_line = 1;
347     int current_column = 0;
348     size_t scratchsize;
349     char *scratchpad, *result;
350   
351     assert(patt && repl && string);
               ^^^^ checks pointers != NULL, but they were already dereferenced above
```

My suggested solution is to move the `assert`-statement up to the top of the function, before the pointers are used (passed to `strlen()`) - so the code becomes like this:

```C
337  char *
338  search_and_replace(char *patt, const char *repl, const char *string, int cursorpos,
339                     int *line, int *col)
340  {
341    assert(patt && repl && string); /* check pointers before using them */
342  
343    int i, j, k;
344    int pattlen = strlen(patt);
345    int replen = strlen(repl);
346    int stringlen = strlen(string);
```