### PR TITLE
support Python 3.10

### DIFF
--- a/filters/rlwrapfilter.py
+++ b/filters/rlwrapfilter.py
@@ -46,7 +46,10 @@ import select
 import re
 import traceback
 import binascii
-import collections
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 import numbers
 
 TAG_INPUT                       = 0
@@ -323,7 +326,7 @@ def is_float(value):
 
 
 def is_callable(value):
-    return isinstance(value, collections.Callable) or value == None
+    return isinstance(value, Callable) or value == None
 
 
 @intercept_error


### PR DESCRIPTION
Please review this PR.
The collections.Callable class which is used in rlwrapfilter.py was copied
to the collections.abc package and had been marked as deprecated since Python
3.3 through 3.9. In Python 3.10, it was finally removed. This fix is for
supporting the latest Python using collections.abc.Callable in rlwrapfilter.py
and providing backward compatibility for running on older versions of Python as
well.
