### PR TITLE
Bind TAB to self-insert if no completions are performed

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -945,6 +945,9 @@ read_options_and_command_name(int argc, char **argv)
       add2strings(rl_basic_word_break_characters, "/.");
   }
 
+  if (!complete_filenames && !opt_f && !remember_for_completion && !always_readline) { /* https://github.com/hanslub42/rlwrap/issues/147 */
+    rl_bind_key('\t', rl_insert);
+  }
   
   if (optind >= argc) { /* rlwrap -a -b -c with no command specified */
     if (filter_command) { /* rlwrap -z filter with no command specified */


### PR DESCRIPTION
This is useful for using rlwrap with interactive programs where a literally character may be entered often and completions are not used. A common example would be text editor such as `ed(1)` or `ex(1)`.

As an occasional user of `ed`, I personally find this feature very handy. Since this has been an open issue for a while (#147) I decided to come up with a patch myself to (hopefully) get this integrated into mainline. I hope I implemented the checks in accordance with the description in #147. If I missed anything please let me know. Some light testing on my systems hasn't revealed any issue.

Fixes #147