### PR TITLE
add .editorconfig for unified indent style / add testit.trs to ignore git

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+---
+BasedOnStyle: Google
+ColumnLimit: 120
+IndentWidth: 4
+
+# style of align
+AlignConsecutiveDeclarations: true
+AlignConsecutiveAssignments: true
+AlignTrailingComments: true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,72 @@
+## EditorConfig is awesome: https://EditorConfig.org
+#
+# @(#)  editorconfig settings for c programming
+#
+# @version  1.0.0
+# @date		2024-03-07
+# @license  GPLv2
+#
+# @description <<
+# user default editorconfig :
+# for c programming with GitHub
+#
+#<<
+
+
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# default character-set
+charset = utf-8
+
+# indent style
+indent_size = tab
+indent_style = tab
+tab_width=4
+
+# ext type settings
+
+# script executable
+[**.]
+indent_style = space
+indent_size = 2
+tab_width = 2
+
+### Programming language
+[**.{c,h}]
+indent_style = tab
+indent_size = tab
+tab_width = 4
+
+# shell script
+[**.{sh,bash}]
+indent_style = space
+indent_size = 2
+tab_width = 2
+
+### setting files
+
+# for git config
+[**.git*]
+indent_style = tab
+indent_size = tab
+tab_width = 4
+
+[**/git/*]
+indent_style = tab
+indent_size = tab
+tab_width = 4
+
+### document, etc
+# markdown
+[**.md]
+indent_size = tab
+tab_width = 2
+indent_style = space
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,19 @@
+##
+#
+# @(#) : rlwrap gitignore
+#
+# @version  1.0.0
+# @date		2024-03-07
+# @license  GPLv2
+#
+# @description <<
+#
+# setting git ignoe files aboout rlwrap development
+# ignore files about created by autotools, c compiler.
+# and man file, Makefile, config.*, .deps
+#
+#<<
+
 Makefile
 Makefile.in
 aclocal.m4
@@ -21,3 +37,5 @@ src/rlwrap
 stamp-h1
 tools/
 filters/RlwrapFilter.3pm
+**testit.trs
+


### PR DESCRIPTION

Add .editorconfig file for unified indent style using EditorConfig.
Ignore testit.trs from git, so add gitignore to testit.trs.

chore:
write header comment on .editotconfig and .gitignore.
