### PR TITLE
Fix SyntaxWarning in rlwrapfilter.py caused by strict escape sequence handling in Python 3.12

### DIFF
--- a/filters/rlwrapfilter.py
+++ b/filters/rlwrapfilter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-"""
+r"""
 Python 3 library for [rlwrap](https://github.com/hanslub42/rlwrap) filters
 
 * Synopsis
@@ -208,7 +208,7 @@ def read_from_stdin():
     tagname = None
     while (tag is None):
         try:
-            m = re.match("(\S+) (.*?)\r?\n", sys.stdin.readline())
+            m = re.match(r"(\S+) (.*?)\r?\n", sys.stdin.readline())
         except KeyboardInterrupt:
             sys.exit()
         if not m:


### PR DESCRIPTION
The rlwrapfilter.py with python 3.12 thows SyntaxWarning due to the changes on strict handling of escape sequences [1].
Please review this PR to fix the issue.

Thanks in advance.

[1] https://docs.python.org/3/whatsnew/3.12.html#other-language-changes