### PR TITLE
solve `SyntaxWarning: invalid escape sequence '\s'` errors

### DIFF
--- a/filters/ftp_filter.py
+++ b/filters/ftp_filter.py
@@ -54,7 +54,7 @@ def listing (dir, where, what):
 
     pattern = "^d" if what == "directories" else "^-"
     lines = [l for l in lines if re.search(pattern, l)] # makes only sense if there is a column with drwxr-xr-x
-    results = [re.split('\s+', l)[dir_filename_column[where]] for l in lines]
+    results = [re.split(r'\s+', l)[dir_filename_column[where]] for l in lines]
     return results
 
 
@@ -97,7 +97,7 @@ def commands():
 
 def complete_handler(line, prefix, completions):
 
-    nwords = len(re.split('\s+', line))
+    nwords = len(re.split(r'\s+', line))
     if prefix == None:
         nwords += 1 # TAB at start of a new (empty) argument
 
@@ -105,8 +105,8 @@ def complete_handler(line, prefix, completions):
         completions.extend([c for c in ftp_commands if re.search(r'^' + prefix, c)])
         return completions
 
-    command = re.search('\s*(\S+)', line).group(1)
-    prefix_match = re.search('((.*)/)?([^/]*)', prefix)
+    command = re.search(r'\s*(\S+)', line).group(1)
+    prefix_match = re.search(r'((.*)/)?([^/]*)', prefix)
     dir = prefix_match.group(2)
     name_prefix = prefix_match.group(3)
     #dir = '.' if dir == None else dir

--- a/filters/rlwrapfilter.py
+++ b/filters/rlwrapfilter.py
@@ -208,7 +208,7 @@ def read_from_stdin():
     tagname = None
     while (tag is None):
         try:
-            m = re.match("(\S+) (.*?)\r?\n", sys.stdin.readline())
+            m = re.match(r'(\S+) (.*?)\r?\n', sys.stdin.readline())
         except KeyboardInterrupt:
             sys.exit()
         if not m:
@@ -493,8 +493,8 @@ class RlwrapFilter:
         response = read_until(CMD_OUT, prompt, timeout,
                               prompt_search_from=prompt_search_from,
                               prompt_search_to=prompt_search_to)
-        response = re.sub('^.*?\n', '', response) # chop off echoed question;
-        response = re.sub('{0}$'.format(prompt), '', response) # chop off prompt;
+        response = re.sub(r'^.*?\n', '', response) # chop off echoed question;
+        response = re.sub(r'{0}$'.format(prompt), '', response) # chop off prompt;
         if (self.cloak_and_dagger_verbose):
             self.send_output_oob("cloak_and_dagger response: {0}\n".format(response))
         return response
@@ -625,14 +625,14 @@ class RlwrapFilter:
                     write_message(tag,REJECT_PROMPT);
                     # don't update <previous_tag> and don't reset <cumulative_input>
                     next
-                if (os.environ.get('RLWRAP_IMPATIENT') and not re.search('\n$', self.cumulative_output)):
+                if (os.environ.get('RLWRAP_IMPATIENT') and not re.search(r'\n$', self.cumulative_output)):
                     # cumulative output contains prompt: chop it off!
                     # s/[^\n]*$// takes way too long on big strings,
                     # what is the optimal regex to do this?
-                    self.cumulative_output = re.sub('(?<![^\n])[^\n]*$', '', self.cumulative_output)
+                    self.cumulative_output = re.sub(r'(?<![^\n])[^\n]*$', '', self.cumulative_output)
 
                 response = when_defined(self.prompt_handler, message)
-                if (re.search('\n', response)):
+                if (re.search(r'\n', response)):
                     send_error('prompts may not contain newlines!')
             elif (tag == TAG_SIGNAL):
                 response = when_defined(self.signal_handler, message)

--- a/filters/rlwrapfilter.py
+++ b/filters/rlwrapfilter.py
@@ -11,7 +11,7 @@ Python 3 library for [rlwrap](https://github.com/hanslub42/rlwrap) filters
     filter.output_handler = lambda x: re.sub('apple', 'orange', x) # re−write output
     filter.prompt_handler = munge_prompt
     filter.completion_handler = complete_handler
-    filter.history_handler = lambda x: re.sub(r'(identified\s+by\s+)(\S+)', r'\\1xXxXxXxX', x)
+    filter.history_handler = lambda x: re.sub(r'(identified\\s+by\\s+)(\\S+)', r'\\1xXxXxXxX', x)
     filter.run()
 
 This is an [RlwrapFilter](https://github.com/hanslub42/rlwrap/wiki/RlwrapFilter.pm-manpage)


### PR DESCRIPTION
Solves the following errors:
```
/usr/share/rlwrap/filters/ftp_filter.py:57: SyntaxWarning: invalid escape sequence '\s'
  results = [re.split('\s+', l)[dir_filename_column[where]] for l in lines]
/usr/share/rlwrap/filters/ftp_filter.py:100: SyntaxWarning: invalid escape sequence '\s'
  nwords = len(re.split('\s+', line))
/usr/share/rlwrap/filters/ftp_filter.py:108: SyntaxWarning: invalid escape sequence '\s'
  command = re.search('\s*(\S+)', line).group(1)
/usr/share/rlwrap/filters/rlwrapfilter.py:4: SyntaxWarning: invalid escape sequence '\s'
  """
/usr/share/rlwrap/filters/rlwrapfilter.py:211: SyntaxWarning: invalid escape sequence '\S'
  m = re.match("(\S+) (.*?)\r?\n", sys.stdin.readline())
```
Pass regexes to `re.split` and `re.match`, escape the `\s` instances in the `"""` documentation. (Some of the changed calls were fine as strings, but this introduces consistency and future-proofs them in the event they change.)