### PR TITLE
Adds an exit handler mechanism to filters.

### DIFF
--- a/filters/RlwrapFilter.pm
+++ b/filters/RlwrapFilter.pm
@@ -15,7 +15,7 @@ require Exporter;
 require AutoLoader;
 @ISA = qw(Exporter AutoLoader);
 
-@EXPORT = qw(TAG_INPUT TAG_OUTPUT TAG_HISTORY TAG_COMPLETION TAG_PROMPT TAG_HOTKEY TAG_SIGNAL DEBUG_FILTERING DEBUG_RANDOM_DELAY);
+@EXPORT = qw(TAG_INPUT TAG_OUTPUT TAG_HISTORY TAG_COMPLETION TAG_PROMPT TAG_HOTKEY TAG_SIGNAL TAG_EXIT DEBUG_FILTERING DEBUG_RANDOM_DELAY);
 $VERSION = '0.01';
 
 use Carp;
@@ -29,6 +29,7 @@ use constant TAG_COMPLETION                    => 3;
 use constant TAG_PROMPT                        => 4;
 use constant TAG_HOTKEY                        => 5;
 use constant TAG_SIGNAL                        => 6;
+use constant TAG_EXIT                          => 7;
 use constant TAG_WHAT_ARE_YOUR_INTERESTS       => 127;
 use constant TAG_IGNORE                        => 251;
 use constant TAG_ADD_TO_COMPLETION_LIST        => 252;
@@ -99,7 +100,7 @@ sub new {
   my @accessors = qw(initialiser help_text input_handler
 		   output_handler prompt_handler echo_handler
 		   message_handler history_handler hotkey_handler completion_handler signal_handler
-		   echo_handler message_handler cloak_and_dagger_verbose
+		   exit_handler echo_handler message_handler cloak_and_dagger_verbose
 		   cumulative_output prompts_are_never_empty
 		   minimal_rlwrap_version);
   foreach my $acc (@accessors) {
@@ -160,6 +161,8 @@ sub run {
       croak "prompts may not contain newlines!" if $response =~ /\n/;
     } elsif ($tag == TAG_SIGNAL) {
       $response = when_defined($self -> signal_handler, $message);
+    } elsif ($tag == TAG_EXIT) {
+    $response = when_defined($self -> exit_handler, $message);
     } elsif ($tag == TAG_WHAT_ARE_YOUR_INTERESTS) {
       $response = $self -> add_interests($message);
     }
@@ -206,7 +209,8 @@ sub add_interests {
       or ($tag == TAG_COMPLETION and $self -> completion_handler)
       or ($tag == TAG_PROMPT     and $self -> prompt_handler)
       or ($tag == TAG_HOTKEY     and $self -> hotkey_handler)
-      or ($tag == TAG_SIGNAL     and $self -> signal_handler);
+      or ($tag == TAG_SIGNAL     and $self -> signal_handler)
+      or ($tag == TAG_EXIT       and $self -> exit_handler);
   }
   return join '', @interested;
 }

--- a/filters/logger
+++ b/filters/logger
@@ -26,6 +26,7 @@ if ($opt_i) {
     $filter -> echo_handler(\&just_copy);
     $filter -> output_handler(\&just_copy);
     $filter -> signal_handler(\&just_copy);
+    $filter -> exit_handler(\&just_copy);
     $filter -> hotkey_handler(\&just_copy_array);
 }
 

--- a/filters/logger.py
+++ b/filters/logger.py
@@ -72,6 +72,7 @@ if args.log_all:
     filter.echo_handler = just_copy
     filter.hotkey_handler = just_copy_list
     filter.signal_handler = just_copy
+    filter.exit_handler = just_copy
 
 
 
@@ -80,9 +81,9 @@ filter.help_text = "Usage: rlwrap -z 'logger [-i] [-l] [logfile]' <command>\n"\
                    + "give logfile name as an argument (default: /tmp/filterlog.$$), -l for long format\n"\
                    + "useful in a pipeline (rlwrap -z 'pipeline logger in:filter:logger out')\n"\
                    + "the -i option will make logger log all message types, not just those that are\n"\
-                   + "relevant for filters up- or downstream in the pipeline" 
+                   + "relevant for filters up- or downstream in the pipeline"
 
 #filter.help_text = parser.format_help()
- 
+
 
 filter.run()

--- a/filters/rlwrapfilter.py
+++ b/filters/rlwrapfilter.py
@@ -61,6 +61,7 @@ TAG_COMPLETION                  = 3
 TAG_PROMPT                      = 4
 TAG_HOTKEY                      = 5
 TAG_SIGNAL                      = 6
+TAG_EXIT                        = 7
 TAG_WHAT_ARE_YOUR_INTERESTS     = 127
 TAG_IGNORE                      = 251
 TAG_ADD_TO_COMPLETION_LIST      = 252
@@ -246,6 +247,7 @@ def tag2name(tag):
                  'TAG_COMPLETION',
                  'TAG_HOTKEY',
                  'TAG_SIGNAL',
+                 'TAG_EXIT',
                  'TAG_HISTORY',
                  'TAG_OUTPUT_OUT_OF_BAND',
                  'TAG_ERROR',
@@ -415,6 +417,7 @@ class RlwrapFilter:
             'prompt_handler':is_callable,
             'hotkey_handler':is_callable,
             'signal_handler':is_callable,
+            'exit_handler':is_callable,
             'echo_handler':is_callable,
             'message_handler':is_callable,
             'history_handler':is_callable,
@@ -529,7 +532,8 @@ class RlwrapFilter:
                        TAG_COMPLETION  : self.completion_handler,
                        TAG_PROMPT      : self.prompt_handler,
                        TAG_HOTKEY      : self.hotkey_handler,
-                       TAG_SIGNAL      : self.signal_handler}
+                       TAG_SIGNAL      : self.signal_handler,
+                       TAG_EXIT        : self.exit_handler}
 
         for tag in range(0, len(message)):
             if interested[tag] == 'y':
@@ -641,6 +645,8 @@ class RlwrapFilter:
                     send_error('prompts may not contain newlines!')
             elif (tag == TAG_SIGNAL):
                 response = when_defined(self.signal_handler, message)
+            elif (tag == TAG_EXIT):
+                response = when_defined(self.exit_handler, message)
             elif (tag == TAG_WHAT_ARE_YOUR_INTERESTS):
                 response = self.add_interests(message)
             else:

--- a/src/filter.c
+++ b/src/filter.c
@@ -173,6 +173,7 @@ void spawn_filter(const char *filter_commandline) {
 void kill_filter(void)  {
   int status;
   assert (filter_pid && filter_input_fd);
+  pass_through_filter(TAG_EXIT, "");
   close(filter_input_fd); /* filter will see EOF and should exit  */
   myalarm(40); /* give filter 0.04seconds to go away */
   if(!filter_is_dead &&                     /* filter's SIGCHLD hasn't been caught  */
@@ -356,6 +357,7 @@ static char* tag2description(int tag) {
   case TAG_PROMPT:                     return "PROMPT";
   case TAG_HOTKEY:                     return "HOTKEY";
   case TAG_SIGNAL:                     return "SIGNAL";
+  case TAG_EXIT:                       return "EXIT";
   case TAG_WHAT_ARE_YOUR_INTERESTS:    return "WHAT_ARE_YOUR_INTERESTS";
   case TAG_IGNORE:                     return "TAG_IGNORE";
   case TAG_ADD_TO_COMPLETION_LIST:     return "ADD_TO_COMPLETION_LIST";

--- a/src/rlwrap.h
+++ b/src/rlwrap.h
@@ -505,7 +505,8 @@ extern int newline_came_last;
 #define TAG_PROMPT 4
 #define TAG_HOTKEY 5
 #define TAG_SIGNAL 6
-#define MAX_INTERESTING_TAG 6 /* max tag for which the filter can have a handler */
+#define TAG_EXIT 7
+#define MAX_INTERESTING_TAG 7 /* max tag for which the filter can have a handler */
 
 #define TAG_WHAT_ARE_YOUR_INTERESTS 127
 


### PR DESCRIPTION
Hello there,

I propose this PR to add an `exit_handler` TAG in filters.

It basically allows filters to be signalled through a new `TAG_EXIT` that rlwrap is going to exit soon. The tag is sent to the filter right before rlwrap kills it, see `filter.c:L176`: 

```c
//src/filter.c
void kill_filter(void)  {
  int status;
  assert (filter_pid && filter_input_fd);
  pass_through_filter(TAG_EXIT, "");/* <----- right here allow filters to perform actions before stopping */
  close(filter_input_fd); /* filter will see EOF and should exit  */
  myalarm(40); /* give filter 0.04seconds to go away */
  if(!filter_is_dead &&                     /* filter's SIGCHLD hasn't been caught  */
     waitpid(filter_pid, &status, WNOHANG) < 0 && /* interrupted  .. */
     WTERMSIG(status) == SIGALRM) {         /*  .. by alarm (and not e.g. by SIGCHLD) */
     myerror(WARNING|NOERRNO, "filter didn't die - killing it now");
  }
  if (filter_pid)
    kill(filter_pid, SIGKILL); /* do this as a last resort */
  myalarm(0);
}     
```

If I'm missing anything please tell me and I will correct things accordingly.

Thanks a lot for supporting this piece of software till today!